### PR TITLE
Delete tests no longer needed for pet name, species, and gender being nil

### DIFF
--- a/spec/graphql/queries/pets/get_pet_by_id.rb
+++ b/spec/graphql/queries/pets/get_pet_by_id.rb
@@ -37,42 +37,6 @@ RSpec.describe Types::QueryType do
       expect(result["data"]["getPetById"]["applications"]).to eq([])
     end
 
-    it 'errors if pet name is nil' do
-      pet_1 = Pet.create!(id: 1, gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
-
-      result = NotFurgottenSchema.execute(query).as_json
-
-      expect(result["data"]).to be_nil
-      expect(result).to have_key("errors")
-      expect(result["errors"]).to be_an(Array)
-      expect(result["errors"][0]).to have_key("message")
-      expect(result["errors"][0]["message"]).to eq("Cannot return null for non-nullable field Pet.name")
-    end
-
-    it 'errors if pet gender is nil' do
-      pet_1 = Pet.create!(id: 1, name: "Clifford", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
-
-      result = NotFurgottenSchema.execute(query).as_json
-
-      expect(result["data"]).to be_nil
-      expect(result).to have_key("errors")
-      expect(result["errors"]).to be_an(Array)
-      expect(result["errors"][0]).to have_key("message")
-      expect(result["errors"][0]["message"]).to eq("Cannot return null for non-nullable field Pet.gender")
-    end
-
-    it 'errors if pet species is nil' do
-      pet_1 = Pet.create!(id: 1, name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
-
-      result = NotFurgottenSchema.execute(query).as_json
-
-      expect(result["data"]).to be_nil
-      expect(result).to have_key("errors")
-      expect(result["errors"]).to be_an(Array)
-      expect(result["errors"][0]).to have_key("message")
-      expect(result["errors"][0]["message"]).to eq("Cannot return null for non-nullable field Pet.species")
-    end
-
     def query
        <<~GQL
        {


### PR DESCRIPTION
**What changed?**
Removed tests in get_pet_by_id query that don't allow for query to return nil for the pet attributes for name, gender, and species. 

**Why is this change necessary?**
Since adding model validations this is no longer applicable and the model validations now also break test set-up by not allowing us to build pet examples with nil values.

**What changed technically that may impact others?**
Nothing

**How do we test it?**
bundle exec rspec spec/graphql/queries/pets/get_pet_by_id.rb

