### PR TITLE
Image attribute added to Schema

### DIFF
--- a/app/graphql/types/pet_type.rb
+++ b/app/graphql/types/pet_type.rb
@@ -11,6 +11,7 @@ module Types
     field :gender, String, null: false
     field :owner_email, String, null: false
     field :owner_name, String, null: false
+    field :image, String
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     field :applications, [Types::ApplicationType], null: false

--- a/db/migrate/20220401000856_add_image_to_pets.rb
+++ b/db/migrate/20220401000856_add_image_to_pets.rb
@@ -1,0 +1,5 @@
+class AddImageToPets < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pets, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_26_215204) do
+ActiveRecord::Schema.define(version: 2022_04_01_000856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 2022_03_26_215204) do
     t.string "owner_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
   end
 
   add_foreign_key "applications", "pets"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,37 +1,37 @@
 
-pet_1 = Pet.create!(name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
+pet_1 = Pet.create!(name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
 Application.create!(name: "Joe", email:"joe@yahoo.com", description: "I have a large yard and like to go for hikes", pet_id: pet_1.id )
 Application.create!(name: "Maggie", email:"marge@yahoo.com", description: "I have another young dog that I have been looking for a friend for.  I'd love to give Virgil some peace of mind his dog will be ok.", pet_id: pet_1.id )
 
-pet_2 = Pet.create!(name: "Garfield", gender: "M", age: 6, description: "Fat orange cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
+pet_2 = Pet.create!(name: "Garfield", gender: "M", age: 6, description: "Fat orange cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
 Application.create!(name: "Kim", email:"kim@gmail.com", description: "I love cats and live in an apartment", pet_id: pet_2.id )
 Application.create!(name: "Kumar", email:"kumar@yahoo.com", description: "I really want another cat", pet_id: pet_2.id )
 
 pet_3 = Pet.create!(name: "Nermal", gender: "F", age: 3, description: "Gray Tabby", species: "cat", owner_story: "My owner is terminally ill with cancer and only has about 6 months to find me a home", owner_email: "lady@gmail.com", owner_name: "Ethel")
 Application.create!(name: "Harold", email:"harold@gmail.com", description: "I love cats and would like to help Ethel out.", pet_id: pet_3.id )
 
-pet_4 = Pet.create!(name: "Taco", gender: "M", age: 4, description: "brindle bull dog", species: "dog", owner_story: "My owner will be transitioning into a nursing home soon and worries where I will end up", owner_email: "geriatric_guy@yahoo.com", owner_name: "Albert")
+pet_4 = Pet.create!(name: "Taco", gender: "M", age: 4, description: "brindle bull dog", species: "dog", owner_story: "My owner will be transitioning into a nursing home soon and worries where I will end up", owner_email: "geriatric_guy@yahoo.com", owner_name: "Albert", image: "")
 Application.create!(name: "Kerri", email:"kerri@gmail.com", description: "I've worked with animals and had pets all my life. I would like to give Albert peace of mine that Taco will be in good hands.", pet_id: pet_4.id )
 Application.create!(name: "Dave", email:"daveyjones@yahoo.com", description: "I already have 1 bulldog who could use a friend.  I would love to help Albert in the process as well!", pet_id: pet_4.id )
 
-pet_5 = Pet.create!(name: "Midnight", gender: "F", age: 12, description: "short haired black cat", species: "cat", owner_story: "My owner is terminally ill. It stresses her most worrying about what will happen to me.  I am like family to her.", owner_email: "janedoe@yahoo.com", owner_name: "Jane")
+pet_5 = Pet.create!(name: "Midnight", gender: "F", age: 12, description: "short haired black cat", species: "cat", owner_story: "My owner is terminally ill. It stresses her most worrying about what will happen to me.  I am like family to her.", owner_email: "janedoe@yahoo.com", owner_name: "Jane", image: "")
 Application.create(name: "Rob", email: "robert@yahoo.com", description: "I just had to put my cat down and am looking to adopt an older cat to give it its best life.  This is a difficult time for Jane and I want her to feel peace in knowing Midnight will be in good hands", pet_id: pet_5.id)
 
-pet_6 = Pet.create!(name: "TutTut", gender: "M", age: 16, description: "cockatoo", species: "bird", owner_story: "My owner is terminally ill. It stresses her most worrying about what will happen to me.  I am like family to her.", owner_email: "GlendaGood@yahoo.com", owner_name: "Glenda")
+pet_6 = Pet.create!(name: "TutTut", gender: "M", age: 16, description: "cockatoo", species: "bird", owner_story: "My owner is terminally ill. It stresses her most worrying about what will happen to me.  I am like family to her.", owner_email: "GlendaGood@yahoo.com", owner_name: "Glenda", image: "")
 Application.create!(name: "Jack", email:"jackd@gmail.com", description: "I'm an experienced cockatoo owner and would love to give TutTut a new home for Glenda", pet_id: pet_6.id )
 
-pet_7 = Pet.create!(name: "ChiChi", gender: "M", age: 4, description: "parakeet", species: "bird", owner_story: "My owner has to go to assisted living next month and he cannot take me.  He really wants to know I will be in good hands. ", owner_email: "JerryS@gmail.com", owner_name: "Jerry")
+pet_7 = Pet.create!(name: "ChiChi", gender: "M", age: 4, description: "parakeet", species: "bird", owner_story: "My owner has to go to assisted living next month and he cannot take me.  He really wants to know I will be in good hands. ", owner_email: "JerryS@gmail.com", owner_name: "Jerry", image: "")
 Application.create!(name: "Dawn", email:"dawndyd@gmail.com", description: "I would like help Jerry.  My parakeet just passed away so I am able to take ChiChi", pet_id: pet_7.id )
 
-pet_8 = Pet.create!(name: "Charlie", gender: "F", age: 7, description: "rottweiler", species: "dog", owner_story: "My owner has to go to assisted living next month and he cannot take me.  He really wants to know I will be in good hands. ", owner_email: "my_email@gmail.com", owner_name: "Guy")
+pet_8 = Pet.create!(name: "Charlie", gender: "F", age: 7, description: "rottweiler", species: "dog", owner_story: "My owner has to go to assisted living next month and he cannot take me.  He really wants to know I will be in good hands. ", owner_email: "my_email@gmail.com", owner_name: "Guy", image: "")
 Application.create!(name: "Dawn", email:"dawndyd@gmail.com", description: "I would like help Jerry.  My parakeet just passed away so I am able to take ChiChi", pet_id: pet_8.id )
 
-pet_9 = Pet.create!(name: "Mandy", gender: "F", age: 7, description: "yellow labrador retriever", species: "dog", owner_story: "My owner has to go to a nursing home next month and she cannot take me.  She really wants to know I will be in good hands. ", owner_email: "grannyb@gmail.com", owner_name: "Betty")
+pet_9 = Pet.create!(name: "Mandy", gender: "F", age: 7, description: "yellow labrador retriever", species: "dog", owner_story: "My owner has to go to a nursing home next month and she cannot take me.  She really wants to know I will be in good hands. ", owner_email: "grannyb@gmail.com", owner_name: "Betty", image: "")
 Application.create!(name: "Joe", email:"joe@yahoo.com", description: "I have a large yard and like to go for hikes", pet_id: pet_9.id )
 
-pet_10 = Pet.create!(name: "Burt", gender: "M", age: 14, description: "dark gray domestic short hair", species: "cat", owner_story: "My owner has to go to an assisted living facility next month and cannot take me.  They are really worried about where I will end up  I am their only family. ", owner_email: "elderly_person@yahoo.com", owner_name: "Sam")
+pet_10 = Pet.create!(name: "Burt", gender: "M", age: 14, description: "dark gray domestic short hair", species: "cat", owner_story: "My owner has to go to an assisted living facility next month and cannot take me.  They are really worried about where I will end up  I am their only family. ", owner_email: "elderly_person@yahoo.com", owner_name: "Sam", image: "")
 Application.create!(name: "Kerri", email:"kerri@gmail.com", description: "I've worked with animals and had pets all my life. I would like to give Albert peace of mine that Burt will be in good hands.", pet_id: pet_10.id )
 
 #pets without applications
-pet_11 = Pet.create!(name: "Fluffy", gender: "F", age: 3, description: "long haired white cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "margie@gmail.com", owner_name: "Margorie")
-pet_12 = Pet.create!(name: "Bruno", gender: "M", age: 8, description: "high energy weimaraner", species: "dog", owner_story: "My owner is terminally ill and wants to make sure I end up with someone who can love me and go on many walks.", owner_email: "dana@gmail.com", owner_name: "Dana")
+pet_11 = Pet.create!(name: "Fluffy", gender: "F", age: 3, description: "long haired white cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "margie@gmail.com", owner_name: "Margorie", image: "")
+pet_12 = Pet.create!(name: "Bruno", gender: "M", age: 8, description: "high energy weimaraner", species: "dog", owner_story: "My owner is terminally ill and wants to make sure I end up with someone who can love me and go on many walks.", owner_email: "dana@gmail.com", owner_name: "Dana", image: "")

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,7 +27,7 @@ type Pet {
   description: String!
   gender: String!
   id: ID!
-  image: String!
+  image: String
   name: String!
   ownerEmail: String!
   ownerName: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,6 +27,7 @@ type Pet {
   description: String!
   gender: String!
   id: ID!
+  image: String!
   name: String!
   ownerEmail: String!
   ownerName: String!

--- a/schema.json
+++ b/schema.json
@@ -345,6 +345,24 @@
               ]
             },
             {
+              "name": "image",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "name",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -348,13 +348,9 @@
               "name": "image",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/queries/pets/get_all_pets.rb
+++ b/spec/graphql/queries/pets/get_all_pets.rb
@@ -3,18 +3,17 @@ require 'rails_helper'
 RSpec.describe Types::QueryType do
   describe 'display all pets' do
     it 'can query all the pets' do
-      pet_1 = Pet.create!(name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
-      pet_2 = Pet.create!(name: "Garfield", gender: "M", age: 6, description: "Fat orange cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
-      pet_3 = Pet.create!(name: "Nermal", gender: "F", age: 3, description: "Gray Tabby", species: "cat", owner_story: "My owner is terminally ill with cancer and only has about 6 months to find me a home", owner_email: "lady@gmail.com", owner_name: "Ethel")
+      pet_1 = Pet.create!(name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
+      pet_2 = Pet.create!(name: "Garfield", gender: "M", age: 6, description: "Fat orange cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
+      pet_3 = Pet.create!(name: "Nermal", gender: "F", age: 3, description: "Gray Tabby", species: "cat", owner_story: "My owner is terminally ill with cancer and only has about 6 months to find me a home", owner_email: "lady@gmail.com", owner_name: "Ethel", image: "")
 
       result = NotFurgottenSchema.execute(query).as_json
 
       expect(result["data"]["getAllPets"].count).to eq(3)
       expect(result["data"]["getAllPets"].first["name"]).to eq("Clifford")
       expect(result["data"]["getAllPets"].last["name"]).to eq("Nermal")
-
       pets = Pet.all
-      expect(result.dig("data", "getAllPets")).to match_array(pets.map {|pet| {"name" => pet.name, "gender" => pet.gender, "age" => pet.age, "description" => pet.description, "species" => pet.species, "ownerStory" => pet.owner_story, "ownerEmail" => pet.owner_email, "ownerName" => pet.owner_name } })
+      expect(result.dig("data", "getAllPets")).to match_array(pets.map {|pet| {"name" => pet.name, "gender" => pet.gender, "age" => pet.age, "description" => pet.description, "species" => pet.species, "ownerStory" => pet.owner_story, "ownerEmail" => pet.owner_email, "ownerName" => pet.owner_name, "image" => pet.image } })
     end
   end
 
@@ -30,6 +29,7 @@ RSpec.describe Types::QueryType do
          ownerStory
          ownerName
          ownerEmail
+         image
          }
      }
      GQL

--- a/spec/graphql/queries/pets/get_pet_by_id.rb
+++ b/spec/graphql/queries/pets/get_pet_by_id.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe Types::QueryType do
   describe 'display a pet' do
     it 'can query a single pet' do
-      pet_1 = Pet.create!(id: 1, name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
-      pet_2 = Pet.create!(id: 2, name: "Garfield", gender: "M", age: 6, description: "Fat orange cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
+      pet_1 = Pet.create!(id: 1, name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
+      pet_2 = Pet.create!(id: 2, name: "Garfield", gender: "M", age: 6, description: "Fat orange cat", species: "cat", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
       application_1 = Application.create!(name: "Joe", email:"joe@yahoo.com", description: "I have a large yard and like to go for hikes", pet_id: pet_1.id )
       application_2 = Application.create!(name: "Kim", email:"kim@gmail.com", description: "I love cats and live in an apartment", pet_id: pet_2.id )
 
@@ -29,7 +29,7 @@ RSpec.describe Types::QueryType do
     end
 
     it 'returns an empty array if there are not applications for the pet' do
-      pet_1 = Pet.create!(id: 1, name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil")
+      pet_1 = Pet.create!(id: 1, name: "Clifford", gender: "M", age: 2, description: "Big Red Dog, likes kids", species: "dog", owner_story: "My owner is going into assisted living next month and he is worried about what will happen to me", owner_email: "old_dude@gmail.com", owner_name: "Virgil", image: "")
 
       result = NotFurgottenSchema.execute(query).as_json
 
@@ -50,6 +50,7 @@ RSpec.describe Types::QueryType do
          ownerStory
          ownerName
          ownerEmail
+         image
          applications {
            name
            email


### PR DESCRIPTION
What changed?
- added pet image attribute to pet table

Why is this change necessary?
- We would like for the donor to add an image of the pet if available. That's why we don't have to validate pet in model just in case donors aren't able to upload image.

What changed technically that may impact others?
- GraphQL schema has changed as well as the test, make sure you run: **rails graphql:schema:dump** -- to reflect new changes

How do we test it?
- bundle exec rspec spec