### PR TITLE
Image added to pet creation mutation

### DIFF
--- a/app/graphql/mutations/create_pet.rb
+++ b/app/graphql/mutations/create_pet.rb
@@ -7,12 +7,13 @@ class Mutations::CreatePet < Mutations::BaseMutation
   argument :owner_story, String, required: false
   argument :owner_email, String, required: false
   argument :owner_name, String, required: false
+  argument :image, String, required: false
 
   field :pet, Types::PetType
   field :errors, [String], null: false
 
-  def resolve(name:, age:, description:, species:, owner_story:, gender:, owner_email:, owner_name:)
-    pet = Pet.new(name: name, age: age, description: description, species: species.capitalize, owner_story: owner_story, gender: gender.capitalize, owner_email: owner_email, owner_name: owner_name)
+  def resolve(name:, age:, description:, species:, owner_story:, gender:, owner_email:, owner_name:, image:)
+    pet = Pet.new(name: name, age: age, description: description, species: species.capitalize, owner_story: owner_story, gender: gender.capitalize, owner_email: owner_email, owner_name: owner_name, image: image)
     if pet.save
       { pet: pet, errors: [] }
     else

--- a/schema.graphql
+++ b/schema.graphql
@@ -47,6 +47,7 @@ input CreatePetInput {
   clientMutationId: String
   description: String
   gender: String
+  image: String
   name: String
   ownerEmail: String
   ownerName: String

--- a/schema.json
+++ b/schema.json
@@ -431,6 +431,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "image",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null

--- a/spec/graphql/mutations/pets/create_pet_spec.rb
+++ b/spec/graphql/mutations/pets/create_pet_spec.rb
@@ -41,6 +41,7 @@ module Mutations
               ownerStory: "I have to go to assisted living",
               ownerEmail: "person@gmail.com",
               ownerName: "Owner's Name"
+              image: "image_url"
               }) {
                 pet {
                   id,
@@ -50,7 +51,8 @@ module Mutations
                   species,
                   ownerStory,
                   ownerEmail,
-                  ownerName
+                  ownerName,
+                  image
                 }
               errors
               }
@@ -69,7 +71,8 @@ module Mutations
               species: "dog",
               ownerStory: null,
               ownerEmail: "person@gmail.com",
-              ownerName: "Owner's Name"
+              ownerName: "Owner's Name",
+              image: "image_url"
               }) {
                 pet {
                   id,
@@ -80,6 +83,7 @@ module Mutations
                   ownerStory,
                   ownerEmail,
                   ownerName
+                  image
                 }
               errors
               }
@@ -98,7 +102,8 @@ module Mutations
               species: "dog",
               ownerStory: "I have to go to assisted living",
               ownerEmail: "person@gmail.com",
-              ownerName: "Owner's Name"
+              ownerName: "Owner's Name",
+              image: "image_url"
               }) {
                 pet {
                   id,
@@ -109,6 +114,7 @@ module Mutations
                   ownerStory,
                   ownerEmail,
                   ownerName
+                  image
                 }
               errors
               }


### PR DESCRIPTION
**What changed?**
Added image argument and keyword to create pet mutation and tests.

**Why is this change necessary?**
So a pet can be created with an image.

**What changed technically that may impact others?**
Just added image attribute to schema.

**How do we test it?**
bundle exec rspec spec/graphql/mutations/pets/create_pet_spec.rb

